### PR TITLE
Add admin user management API endpoints

### DIFF
--- a/server/controllers/adminUserController.js
+++ b/server/controllers/adminUserController.js
@@ -1,0 +1,494 @@
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const User = require('../models/User');
+const Plan = require('../models/Plan');
+const Token = require('../models/Token');
+const { generateOtp } = require('../utils/otpUtils');
+const { sendNotification } = require('../services/notificationService');
+
+const ACCOUNT_STATUS_CODES = ['active', 'invited', 'suspended', 'disabled'];
+const STATUS_LABELS = {
+    active: 'Active',
+    invited: 'Invited',
+    suspended: 'Suspended',
+    disabled: 'Disabled',
+};
+
+const PASSWORD_RESET_TOKEN_EXPIRY_MINUTES = parseInt(process.env.OTP_EXPIRY_MINUTES || '10', 10);
+
+const formatDate = (value) => {
+    if (!value) {
+        return null;
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    return date.toISOString().split('T')[0];
+};
+
+const normalizeStatusCode = (user) => {
+    const metadataStatus = user?.metadata?.accountStatus;
+    if (metadataStatus && ACCOUNT_STATUS_CODES.includes(metadataStatus)) {
+        return metadataStatus;
+    }
+
+    if (user?.isActive === false) {
+        return 'disabled';
+    }
+
+    return 'active';
+};
+
+const buildStatusUpdate = (statusCode) => {
+    const update = { 'metadata.accountStatus': statusCode };
+
+    if (statusCode === 'suspended' || statusCode === 'disabled') {
+        update.isActive = false;
+    } else {
+        update.isActive = true;
+    }
+
+    return update;
+};
+
+const humanizeStatus = (statusCode) => STATUS_LABELS[statusCode] || statusCode;
+
+const mapUserToResponse = (user, { includeRaw = false } = {}) => {
+    const statusCode = normalizeStatusCode(user);
+    const planDetails = user.planId && typeof user.planId === 'object'
+        ? user.planId
+        : null;
+
+    const response = {
+        id: user._id.toString(),
+        username: user.username,
+        email: user.email,
+        planId: planDetails ? planDetails.slug : null,
+        plan: planDetails ? planDetails.name : null,
+        statusCode,
+        status: humanizeStatus(statusCode),
+        registeredAt: formatDate(user.createdAt),
+        lastLoginAt: formatDate(user.lastLoginAt),
+    };
+
+    if (includeRaw) {
+        response.raw = user;
+    }
+
+    return response;
+};
+
+const resolvePlanIdentifier = async (planIdentifier) => {
+    if (!planIdentifier) {
+        return null;
+    }
+
+    if (mongoose.Types.ObjectId.isValid(planIdentifier)) {
+        const planById = await Plan.findById(planIdentifier).select('_id name slug');
+        if (planById) {
+            return planById;
+        }
+    }
+
+    const planBySlug = await Plan.findOne({ slug: planIdentifier }).select('_id name slug');
+    return planBySlug;
+};
+
+const buildStatusFilterCondition = (statusCode) => {
+    switch (statusCode) {
+        case 'active':
+            return {
+                $or: [
+                    { 'metadata.accountStatus': 'active' },
+                    {
+                        'metadata.accountStatus': { $exists: false },
+                        isActive: { $ne: false },
+                    },
+                    {
+                        'metadata.accountStatus': { $in: [null, ''] },
+                        isActive: { $ne: false },
+                    },
+                ],
+            };
+        case 'invited':
+            return { 'metadata.accountStatus': 'invited' };
+        case 'suspended':
+            return { 'metadata.accountStatus': 'suspended' };
+        case 'disabled':
+            return {
+                $or: [
+                    { 'metadata.accountStatus': 'disabled' },
+                    { isActive: false },
+                ],
+            };
+        default:
+            return {};
+    }
+};
+
+const generateRandomPassword = () => {
+    const candidate = crypto.randomBytes(12).toString('base64').replace(/[^a-zA-Z0-9]/g, '');
+    if (candidate.length >= 12) {
+        return candidate.slice(0, 16);
+    }
+    return crypto.randomBytes(8).toString('hex');
+};
+
+const createPasswordResetToken = async (userId) => {
+    await Token.deleteMany({ userId, type: 'passwordReset' });
+    const otp = generateOtp(6);
+    const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_EXPIRY_MINUTES * 60 * 1000);
+    const token = new Token({
+        userId,
+        token: otp,
+        type: 'passwordReset',
+        expiresAt,
+    });
+    await token.save();
+    return otp;
+};
+
+const listUsers = async (req, res) => {
+    try {
+        const {
+            search,
+            status,
+            planId: planIdentifier,
+            page: pageParam,
+            pageSize: pageSizeParam,
+        } = req.query;
+
+        const filters = [];
+
+        if (search) {
+            const regex = new RegExp(search, 'i');
+            filters.push({
+                $or: [
+                    { username: regex },
+                    { email: regex },
+                ],
+            });
+        }
+
+        if (status) {
+            if (!ACCOUNT_STATUS_CODES.includes(status)) {
+                return res.status(400).json({ message: `Invalid status filter '${status}'.` });
+            }
+            filters.push(buildStatusFilterCondition(status));
+        }
+
+        if (planIdentifier) {
+            const plan = await resolvePlanIdentifier(planIdentifier);
+            if (!plan) {
+                return res.status(400).json({ message: `Plan '${planIdentifier}' not found.` });
+            }
+            filters.push({ planId: plan._id });
+        }
+
+        const page = Math.max(parseInt(pageParam, 10) || 1, 1);
+        const pageSizeRaw = parseInt(pageSizeParam, 10) || 25;
+        const pageSize = Math.min(Math.max(pageSizeRaw, 1), 100);
+
+        const query = filters.length > 0 ? { $and: filters } : {};
+
+        const totalItems = await User.countDocuments(query);
+        const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / pageSize);
+        const skip = (page - 1) * pageSize;
+
+        const users = await User.find(query)
+            .sort({ createdAt: -1 })
+            .skip(skip)
+            .limit(pageSize)
+            .populate('planId', 'name slug')
+            .lean({ virtuals: true });
+
+        const items = users.map((user) => mapUserToResponse(user));
+
+        const statusAggregation = await User.aggregate([
+            {
+                $addFields: {
+                    metadataStatus: '$metadata.accountStatus',
+                },
+            },
+            {
+                $addFields: {
+                    computedStatus: {
+                        $switch: {
+                            branches: [
+                                {
+                                    case: { $in: ['$metadataStatus', ACCOUNT_STATUS_CODES] },
+                                    then: '$metadataStatus',
+                                },
+                                {
+                                    case: { $eq: ['$isActive', false] },
+                                    then: 'disabled',
+                                },
+                            ],
+                            default: 'active',
+                        },
+                    },
+                },
+            },
+            {
+                $group: {
+                    _id: null,
+                    statuses: { $addToSet: '$computedStatus' },
+                },
+            },
+        ]);
+
+        const aggregatedStatuses = new Set(statusAggregation[0]?.statuses || []);
+        const availableStatuses = ACCOUNT_STATUS_CODES.filter((code) => aggregatedStatuses.has(code));
+
+        return res.status(200).json({
+            items,
+            pagination: {
+                currentPage: page,
+                totalPages,
+                totalItems,
+                itemsPerPage: pageSize,
+            },
+            availableStatuses,
+        });
+    } catch (error) {
+        console.error('Error listing admin users:', error);
+        return res.status(500).json({ message: 'Failed to list users.' });
+    }
+};
+
+const getUserProfile = async (req, res) => {
+    try {
+        const { userId } = req.params;
+
+        if (!mongoose.Types.ObjectId.isValid(userId)) {
+            return res.status(400).json({ message: 'Invalid user ID.' });
+        }
+
+        const user = await User.findById(userId)
+            .populate('planId', 'name slug')
+            .lean({ virtuals: true });
+
+        if (!user) {
+            return res.status(404).json({ message: 'User not found.' });
+        }
+
+        return res.status(200).json(mapUserToResponse(user, { includeRaw: true }));
+    } catch (error) {
+        console.error('Error fetching admin user profile:', error);
+        return res.status(500).json({ message: 'Failed to fetch user profile.' });
+    }
+};
+
+const createUser = async (req, res) => {
+    try {
+        const { username, email, password, planId: planIdentifier, status } = req.body;
+
+        if (!username || !email) {
+            return res.status(400).json({ message: 'Username and email are required.' });
+        }
+
+        if (await User.exists({ username })) {
+            return res.status(409).json({ message: 'Username already exists.' });
+        }
+
+        if (await User.exists({ email })) {
+            return res.status(409).json({ message: 'Email already exists.' });
+        }
+
+        const statusCode = status && ACCOUNT_STATUS_CODES.includes(status) ? status : 'active';
+        let resolvedPlan = null;
+
+        if (planIdentifier) {
+            resolvedPlan = await resolvePlanIdentifier(planIdentifier);
+            if (!resolvedPlan) {
+                return res.status(400).json({ message: `Plan '${planIdentifier}' not found.` });
+            }
+        }
+
+        if (!password && statusCode !== 'invited') {
+            return res.status(400).json({ message: 'Password is required unless creating an invited user.' });
+        }
+
+        const passwordToStore = password || generateRandomPassword();
+
+        const newUser = new User({
+            username,
+            email,
+            password_hash: passwordToStore,
+            planId: resolvedPlan ? resolvedPlan._id : undefined,
+            metadata: {
+                ...(statusCode ? { accountStatus: statusCode } : {}),
+            },
+            isActive: statusCode === 'suspended' || statusCode === 'disabled' ? false : true,
+        });
+
+        await newUser.save();
+
+        const savedUser = await User.findById(newUser._id)
+            .populate('planId', 'name slug')
+            .lean({ virtuals: true });
+
+        return res.status(201).json(mapUserToResponse(savedUser));
+    } catch (error) {
+        console.error('Error creating admin user:', error);
+        return res.status(500).json({ message: 'Failed to create user.' });
+    }
+};
+
+const updateUser = async (req, res) => {
+    try {
+        const { userId } = req.params;
+        const { username, email, planId: planIdentifier, status } = req.body;
+
+        if (!mongoose.Types.ObjectId.isValid(userId)) {
+            return res.status(400).json({ message: 'Invalid user ID.' });
+        }
+
+        const updates = {};
+
+        if (username) {
+            const existingUsername = await User.findOne({ username, _id: { $ne: userId } });
+            if (existingUsername) {
+                return res.status(409).json({ message: 'Username already exists.' });
+            }
+            updates.username = username;
+        }
+
+        if (email) {
+            const existingEmail = await User.findOne({ email, _id: { $ne: userId } });
+            if (existingEmail) {
+                return res.status(409).json({ message: 'Email already exists.' });
+            }
+            updates.email = email;
+        }
+
+        if (planIdentifier) {
+            const resolvedPlan = await resolvePlanIdentifier(planIdentifier);
+            if (!resolvedPlan) {
+                return res.status(400).json({ message: `Plan '${planIdentifier}' not found.` });
+            }
+            updates.planId = resolvedPlan._id;
+        }
+
+        if (status) {
+            if (!ACCOUNT_STATUS_CODES.includes(status)) {
+                return res.status(400).json({ message: `Invalid status '${status}'.` });
+            }
+            Object.assign(updates, buildStatusUpdate(status));
+        }
+
+        if (Object.keys(updates).length === 0) {
+            return res.status(400).json({ message: 'No valid fields provided for update.' });
+        }
+
+        const updatedUser = await User.findByIdAndUpdate(
+            userId,
+            { $set: updates },
+            { new: true, runValidators: true, context: 'query' },
+        )
+            .populate('planId', 'name slug')
+            .lean({ virtuals: true });
+
+        if (!updatedUser) {
+            return res.status(404).json({ message: 'User not found.' });
+        }
+
+        return res.status(200).json(mapUserToResponse(updatedUser));
+    } catch (error) {
+        console.error('Error updating admin user:', error);
+        return res.status(500).json({ message: 'Failed to update user.' });
+    }
+};
+
+const updateUserStatus = async (req, res) => {
+    try {
+        const { userId } = req.params;
+        const { status } = req.body;
+
+        if (!mongoose.Types.ObjectId.isValid(userId)) {
+            return res.status(400).json({ message: 'Invalid user ID.' });
+        }
+
+        if (!status || !ACCOUNT_STATUS_CODES.includes(status)) {
+            return res.status(400).json({ message: 'A valid status is required.' });
+        }
+
+        const statusUpdate = buildStatusUpdate(status);
+
+        const updatedUser = await User.findByIdAndUpdate(
+            userId,
+            { $set: statusUpdate },
+            { new: true, runValidators: true, context: 'query' },
+        )
+            .lean({ virtuals: true });
+
+        if (!updatedUser) {
+            return res.status(404).json({ message: 'User not found.' });
+        }
+
+        const statusCode = normalizeStatusCode(updatedUser);
+
+        return res.status(200).json({
+            id: updatedUser._id.toString(),
+            statusCode,
+            status: humanizeStatus(statusCode),
+        });
+    } catch (error) {
+        console.error('Error updating admin user status:', error);
+        return res.status(500).json({ message: 'Failed to update user status.' });
+    }
+};
+
+const triggerPasswordReset = async (req, res) => {
+    try {
+        const { userId } = req.params;
+        const { redirectUri } = req.body || {};
+
+        if (!mongoose.Types.ObjectId.isValid(userId)) {
+            return res.status(400).json({ message: 'Invalid user ID.' });
+        }
+
+        const user = await User.findById(userId);
+
+        if (!user) {
+            return res.status(404).json({ message: 'User not found.' });
+        }
+
+        const resetToken = await createPasswordResetToken(user._id);
+
+        const resetLink = redirectUri || process.env.DEFAULT_PASSWORD_RESET_REDIRECT;
+
+        let messageBody = `A password reset was requested by an administrator. Use OTP: ${resetToken}.`;
+
+        if (resetLink) {
+            messageBody += `\nAfter resetting the password, you will be redirected to: ${resetLink}`;
+        }
+
+        const notificationScheduled = await sendNotification({
+            method: 'email',
+            user,
+            subject: 'Password Reset Requested',
+            text: messageBody,
+        });
+
+        if (!notificationScheduled) {
+            return res.status(500).json({ message: 'Failed to schedule password reset email.' });
+        }
+
+        return res.status(202).json({ message: 'Password reset email scheduled' });
+    } catch (error) {
+        console.error('Error triggering password reset for admin user:', error);
+        return res.status(500).json({ message: 'Failed to trigger password reset.' });
+    }
+};
+
+module.exports = {
+    listUsers,
+    getUserProfile,
+    createUser,
+    updateUser,
+    updateUserStatus,
+    triggerPasswordReset,
+    ACCOUNT_STATUS_CODES,
+};

--- a/server/routes/adminUsers.js
+++ b/server/routes/adminUsers.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const { body, query } = require('express-validator');
+const router = express.Router();
+
+const adminUserController = require('../controllers/adminUserController');
+const { authenticate } = require('../middleware/authMiddleware');
+const { authorize } = require('../middleware/casbinAuthorize');
+const { handleValidationErrors } = require('../validators/validatorsIndex');
+
+const { ACCOUNT_STATUS_CODES } = adminUserController;
+
+const statusValidator = body('status').optional().isIn(ACCOUNT_STATUS_CODES);
+
+router.get(
+    '/',
+    authenticate,
+    authorize('admin'),
+    [
+        query('status').optional().isIn(ACCOUNT_STATUS_CODES),
+        query('page').optional().isInt({ min: 1 }),
+        query('pageSize').optional().isInt({ min: 1, max: 100 }),
+    ],
+    handleValidationErrors,
+    adminUserController.listUsers,
+);
+
+router.get(
+    '/:userId',
+    authenticate,
+    authorize('admin'),
+    adminUserController.getUserProfile,
+);
+
+router.post(
+    '/',
+    [
+        body('username').isString().trim().notEmpty(),
+        body('email').isEmail().normalizeEmail(),
+        body('password').optional().isString().isLength({ min: 6 }),
+        body('planId').optional().isString().trim(),
+        statusValidator,
+    ],
+    handleValidationErrors,
+    authenticate,
+    authorize('admin'),
+    adminUserController.createUser,
+);
+
+router.patch(
+    '/:userId',
+    [
+        body('username').optional().isString().trim().notEmpty(),
+        body('email').optional().isEmail().normalizeEmail(),
+        body('planId').optional().isString().trim(),
+        statusValidator,
+    ],
+    handleValidationErrors,
+    authenticate,
+    authorize('admin'),
+    adminUserController.updateUser,
+);
+
+router.patch(
+    '/:userId/status',
+    [
+        body('status').exists().isIn(ACCOUNT_STATUS_CODES),
+    ],
+    handleValidationErrors,
+    authenticate,
+    authorize('admin'),
+    adminUserController.updateUserStatus,
+);
+
+router.post(
+    '/:userId/reset-password',
+    [
+        body('redirectUri').optional().isURL(),
+    ],
+    handleValidationErrors,
+    authenticate,
+    authorize('admin'),
+    adminUserController.triggerPasswordReset,
+);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ const connectDB = require('./config/database');
 const userRoutes = require('./routes/user');
 const authRoutes = require('./routes/authRoutes');
 const planRoutes = require('./routes/plan');
+const adminUserRoutes = require('./routes/adminUsers');
 const { initializeEnforcer } = require('./services/casbin');
 const { scheduleSubscriptionExpiryCheck } = require('./jobs/subscriptionJobs');
 const AppError = require('./utils/AppError');
@@ -46,6 +47,7 @@ app.get('/', (req, res) => {
 app.use('/api/users', userRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/plans', planRoutes);
+app.use('/api/admin/users', adminUserRoutes);
 
 
 // Handle 404 Not Found for any routes not matched above


### PR DESCRIPTION
## Summary
- add a dedicated admin user controller with listing, CRUD, status management, and password reset helpers that respect existing schema fields
- expose `/api/admin/users` routes with validation plus authentication/authorization
- register the admin user routes in the main Express app

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68dd00a3eec8832ea9a5168354e57f8c