### PR TITLE
Add project and transaction APIs

### DIFF
--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -1,0 +1,355 @@
+const mongoose = require('mongoose');
+const Project = require('../models/Project');
+const Transaction = require('../models/Transaction');
+
+const { Types } = mongoose;
+
+const isValidObjectId = (value) => Types.ObjectId.isValid(value);
+
+const escapeRegex = (value = '') => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const mapProject = (project) => ({
+    id: project._id.toString(),
+    name: project.name,
+    description: project.description || '',
+    currency: project.currency,
+    createdAt: toResponseDate(project.createdAt),
+    updatedAt: project.updatedAt ? project.updatedAt.toISOString() : null,
+});
+
+const toResponseDate = (date) => {
+    if (!date) {
+        return null;
+    }
+    try {
+        return date.toISOString().slice(0, 10);
+    } catch (error) {
+        return null;
+    }
+};
+
+const mapTransaction = (transaction) => ({
+    id: transaction._id.toString(),
+    projectId: transaction.project_id.toString(),
+    date: toResponseDate(transaction.transaction_date),
+    type: transaction.type === 'cash_out' ? 'Expense' : 'Income',
+    amount: transaction.amount,
+    subcategory: transaction.subcategory,
+    description: transaction.description || '',
+    createdAt: transaction.createdAt ? transaction.createdAt.toISOString() : null,
+    updatedAt: transaction.updatedAt ? transaction.updatedAt.toISOString() : null,
+});
+
+const ensureProjectOwnership = async (projectId, userId) => {
+    if (!isValidObjectId(projectId)) {
+        return null;
+    }
+
+    const project = await Project.findOne({ _id: projectId, user_id: userId });
+    return project;
+};
+
+const getProjects = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { search, sort } = req.query;
+
+        const query = { user_id: userId };
+        if (search && typeof search === 'string') {
+            query.name = { $regex: new RegExp(escapeRegex(search.trim()), 'i') };
+        }
+
+        const sortDirection = sort === 'oldest' ? 1 : -1;
+        const projects = await Project.find(query)
+            .sort({ createdAt: sortDirection })
+            .lean();
+
+        res.status(200).json({
+            projects: projects.map(mapProject),
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const createProject = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const name = req.body.name.trim();
+        const description = (req.body.description || '').trim();
+        const currency = (req.body.currency || 'BDT').trim().toUpperCase();
+
+        const duplicate = await Project.findOne({
+            user_id: userId,
+            name: { $regex: new RegExp(`^${escapeRegex(name)}$`, 'i') },
+        });
+
+        if (duplicate) {
+            return res.status(409).json({
+                message: 'A project with this name already exists.',
+            });
+        }
+
+        const project = await Project.create({
+            user_id: userId,
+            name,
+            description,
+            currency,
+        });
+
+        res.status(201).json({ project: mapProject(project) });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const updateProject = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId } = req.params;
+
+        if (!isValidObjectId(projectId)) {
+            return res.status(400).json({ message: 'Invalid project identifier.' });
+        }
+
+        const project = await Project.findOne({ _id: projectId, user_id: userId });
+
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const updates = {};
+        if (typeof req.body.name === 'string') {
+            updates.name = req.body.name.trim();
+        }
+        if (typeof req.body.description === 'string') {
+            updates.description = req.body.description.trim();
+        }
+        if (typeof req.body.currency === 'string') {
+            updates.currency = req.body.currency.trim().toUpperCase();
+        }
+
+        if (updates.name && updates.name.toLowerCase() !== project.name.toLowerCase()) {
+            const conflict = await Project.findOne({
+                _id: { $ne: projectId },
+                user_id: userId,
+                name: { $regex: new RegExp(`^${escapeRegex(updates.name)}$`, 'i') },
+            });
+            if (conflict) {
+                return res.status(409).json({ message: 'A project with this name already exists.' });
+            }
+        }
+
+        Object.assign(project, updates);
+        await project.save();
+
+        res.status(200).json({ project: mapProject(project) });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const deleteProject = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId } = req.params;
+
+        if (!isValidObjectId(projectId)) {
+            return res.status(400).json({ message: 'Invalid project identifier.' });
+        }
+
+        const project = await Project.findOneAndDelete({ _id: projectId, user_id: userId });
+
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        await Transaction.deleteMany({ project_id: project._id, user_id: userId });
+
+        res.status(200).json({
+            message: 'Project deleted successfully.',
+            projectId: project._id.toString(),
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const getTransactions = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId } = req.params;
+
+        const project = await ensureProjectOwnership(projectId, userId);
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const transactions = await Transaction.find({ project_id: project._id, user_id: userId })
+            .sort({ transaction_date: -1, createdAt: -1 })
+            .lean();
+
+        res.status(200).json({
+            project: mapProject(project),
+            transactions: transactions.map(mapTransaction),
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const toStorageType = (type) => {
+    if (type === 'income') {
+        return 'cash_in';
+    }
+    if (type === 'expense') {
+        return 'cash_out';
+    }
+    return null;
+};
+
+const parseTransactionDate = (value) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    return date;
+};
+
+const createTransaction = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId } = req.params;
+
+        const project = await ensureProjectOwnership(projectId, userId);
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const { date, type, amount, subcategory, description } = req.body;
+        const transactionDate = parseTransactionDate(date);
+
+        const storageType = toStorageType(type);
+        if (!storageType) {
+            return res.status(400).json({ message: 'Invalid transaction type provided.' });
+        }
+
+        if (!transactionDate) {
+            return res.status(400).json({ message: 'Invalid transaction date provided.' });
+        }
+
+        const transaction = await Transaction.create({
+            project_id: project._id,
+            user_id: userId,
+            type: storageType,
+            amount,
+            subcategory: subcategory.trim(),
+            description: (description || '').trim(),
+            transaction_date: transactionDate,
+        });
+
+        res.status(201).json({ transaction: mapTransaction(transaction) });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const updateTransaction = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId, transactionId } = req.params;
+
+        if (!isValidObjectId(transactionId)) {
+            return res.status(400).json({ message: 'Invalid transaction identifier.' });
+        }
+
+        const project = await ensureProjectOwnership(projectId, userId);
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const transaction = await Transaction.findOne({
+            _id: transactionId,
+            project_id: project._id,
+            user_id: userId,
+        });
+
+        if (!transaction) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        if (typeof req.body.type === 'string') {
+            const storageType = toStorageType(req.body.type);
+            if (!storageType) {
+                return res.status(400).json({ message: 'Invalid transaction type provided.' });
+            }
+            transaction.type = storageType;
+        }
+        if (typeof req.body.amount === 'number') {
+            transaction.amount = req.body.amount;
+        }
+        if (typeof req.body.subcategory === 'string') {
+            transaction.subcategory = req.body.subcategory.trim();
+        }
+        if (typeof req.body.description === 'string') {
+            transaction.description = req.body.description.trim();
+        }
+        if (typeof req.body.date === 'string') {
+            const parsedDate = parseTransactionDate(req.body.date);
+            if (!parsedDate) {
+                return res.status(400).json({ message: 'Invalid transaction date provided.' });
+            }
+            transaction.transaction_date = parsedDate;
+        }
+
+        await transaction.save();
+
+        res.status(200).json({ transaction: mapTransaction(transaction) });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const deleteTransaction = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId, transactionId } = req.params;
+
+        if (!isValidObjectId(transactionId)) {
+            return res.status(400).json({ message: 'Invalid transaction identifier.' });
+        }
+
+        const project = await ensureProjectOwnership(projectId, userId);
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const transaction = await Transaction.findOneAndDelete({
+            _id: transactionId,
+            project_id: project._id,
+            user_id: userId,
+        });
+
+        if (!transaction) {
+            return res.status(404).json({ message: 'Transaction not found.' });
+        }
+
+        res.status(200).json({
+            message: 'Transaction deleted successfully.',
+            transactionId: transaction._id.toString(),
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+module.exports = {
+    getProjects,
+    createProject,
+    updateProject,
+    deleteProject,
+    getTransactions,
+    createTransaction,
+    updateTransaction,
+    deleteTransaction,
+};

--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -8,6 +8,27 @@ const isValidObjectId = (value) => Types.ObjectId.isValid(value);
 
 const escapeRegex = (value = '') => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+const clampLimit = (value, { min = 1, max = 100, defaultValue = 20 } = {}) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+        return defaultValue;
+    }
+    return Math.min(Math.max(parsed, min), max);
+};
+
+const toObjectIdOrNull = (value) => {
+    if (!value) {
+        return null;
+    }
+    if (value instanceof Types.ObjectId) {
+        return value;
+    }
+    if (typeof value === 'string' && Types.ObjectId.isValid(value)) {
+        return new Types.ObjectId(value);
+    }
+    return null;
+};
+
 const mapProject = (project) => ({
     id: project._id.toString(),
     name: project.name,
@@ -49,23 +70,102 @@ const ensureProjectOwnership = async (projectId, userId) => {
     return project;
 };
 
+const buildCursorFilter = (direction, fieldName, fieldValue, idValue) => {
+    if (!fieldValue) {
+        return {};
+    }
+
+    const comparisonOperator = direction === 1 ? '$gt' : '$lt';
+    const equalityOperator = direction === 1 ? '$gt' : '$lt';
+
+    return {
+        $or: [
+            { [fieldName]: { [comparisonOperator]: fieldValue } },
+            {
+                [fieldName]: fieldValue,
+                _id: { [equalityOperator]: idValue },
+            },
+        ],
+    };
+};
+
+const buildTransactionCursorFilter = (direction, cursorDoc) => {
+    if (!cursorDoc?.transaction_date) {
+        return {};
+    }
+
+    const comparisonOperator = direction === 1 ? '$gt' : '$lt';
+    const equalityOperator = direction === 1 ? '$gt' : '$lt';
+
+    return {
+        $or: [
+            { transaction_date: { [comparisonOperator]: cursorDoc.transaction_date } },
+            {
+                transaction_date: cursorDoc.transaction_date,
+                _id: { [equalityOperator]: cursorDoc._id },
+            },
+        ],
+    };
+};
+
 const getProjects = async (req, res, next) => {
     try {
         const userId = req.user?._id;
-        const { search, sort } = req.query;
+        const { search, sort, limit: limitParam, cursor } = req.query;
 
-        const query = { user_id: userId };
+        const baseFilters = [{ user_id: userId }];
         if (search && typeof search === 'string') {
-            query.name = { $regex: new RegExp(escapeRegex(search.trim()), 'i') };
+            baseFilters.push({ name: { $regex: new RegExp(escapeRegex(search.trim()), 'i') } });
         }
 
         const sortDirection = sort === 'oldest' ? 1 : -1;
+        const limit = clampLimit(limitParam, { defaultValue: 20 });
+
+        const filters = [...baseFilters];
+
+        if (cursor) {
+            if (!isValidObjectId(cursor)) {
+                return res.status(400).json({ message: 'Invalid cursor value provided.' });
+            }
+
+            const cursorProject = await Project.findOne({ _id: cursor, user_id: userId })
+                .select({ createdAt: 1 })
+                .lean();
+
+            if (!cursorProject) {
+                return res.status(400).json({ message: 'Cursor project could not be found for this user.' });
+            }
+
+            filters.push(
+                buildCursorFilter(sortDirection, 'createdAt', cursorProject.createdAt, cursorProject._id),
+            );
+        }
+
+        const query = filters.length > 1 ? { $and: filters } : filters[0];
+
         const projects = await Project.find(query)
-            .sort({ createdAt: sortDirection })
+            .sort({ createdAt: sortDirection, _id: sortDirection })
+            .limit(limit + 1)
             .lean();
 
+        const hasNextPage = projects.length > limit;
+        const trimmedProjects = hasNextPage ? projects.slice(0, -1) : projects;
+        const nextCursor = hasNextPage
+            ? trimmedProjects[trimmedProjects.length - 1]?._id?.toString() ?? null
+            : null;
+
+        const countFilters = cursor ? baseFilters : filters;
+        const countQuery = countFilters.length > 1 ? { $and: countFilters } : countFilters[0];
+        const totalCount = await Project.countDocuments(countQuery);
+
         res.status(200).json({
-            projects: projects.map(mapProject),
+            projects: trimmedProjects.map(mapProject),
+            pageInfo: {
+                hasNextPage,
+                nextCursor,
+                limit,
+            },
+            totalCount,
         });
     } catch (error) {
         next(error);
@@ -179,19 +279,145 @@ const getTransactions = async (req, res, next) => {
     try {
         const userId = req.user?._id;
         const { projectId } = req.params;
+        const {
+            limit: limitParam,
+            cursor,
+            sort,
+            type,
+            search,
+            startDate,
+            endDate,
+        } = req.query;
 
         const project = await ensureProjectOwnership(projectId, userId);
         if (!project) {
             return res.status(404).json({ message: 'Project not found.' });
         }
 
-        const transactions = await Transaction.find({ project_id: project._id, user_id: userId })
-            .sort({ transaction_date: -1, createdAt: -1 })
+        const userIdentifier = toObjectIdOrNull(userId) ?? userId;
+        const filters = [{ project_id: project._id, user_id: userIdentifier }];
+
+        if (type) {
+            const storageType = toStorageType(type);
+            if (!storageType) {
+                return res.status(400).json({ message: 'Invalid transaction type filter provided.' });
+            }
+            filters.push({ type: storageType });
+        }
+
+        if (search) {
+            const expression = new RegExp(escapeRegex(search.trim()), 'i');
+            filters.push({
+                $or: [
+                    { description: { $regex: expression } },
+                    { subcategory: { $regex: expression } },
+                ],
+            });
+        }
+
+        if (startDate || endDate) {
+            const dateFilter = {};
+            if (startDate) {
+                const parsedStart = parseTransactionDate(startDate);
+                if (!parsedStart) {
+                    return res.status(400).json({ message: 'Invalid startDate provided.' });
+                }
+                dateFilter.$gte = parsedStart;
+            }
+            if (endDate) {
+                const parsedEnd = parseTransactionDate(endDate);
+                if (!parsedEnd) {
+                    return res.status(400).json({ message: 'Invalid endDate provided.' });
+                }
+                dateFilter.$lte = parsedEnd;
+            }
+
+            if (dateFilter.$gte && dateFilter.$lte && dateFilter.$gte > dateFilter.$lte) {
+                return res.status(400).json({ message: 'startDate cannot be later than endDate.' });
+            }
+
+            filters.push({ transaction_date: dateFilter });
+        }
+
+        const limit = clampLimit(limitParam, { defaultValue: 20 });
+        const sortDirection = sort === 'oldest' ? 1 : -1;
+
+        if (cursor) {
+            if (!isValidObjectId(cursor)) {
+                return res.status(400).json({ message: 'Invalid cursor value provided.' });
+            }
+
+            const cursorTransaction = await Transaction.findOne({
+                _id: cursor,
+                project_id: project._id,
+                user_id: userId,
+            })
+                .select({ transaction_date: 1 })
+                .lean();
+
+            if (!cursorTransaction) {
+                return res.status(400).json({ message: 'Cursor transaction could not be found for this project.' });
+            }
+
+            filters.push(buildTransactionCursorFilter(sortDirection, cursorTransaction));
+        }
+
+        const query = filters.length > 1 ? { $and: filters } : filters[0];
+
+        const transactions = await Transaction.find(query)
+            .sort({ transaction_date: sortDirection, _id: sortDirection })
+            .limit(limit + 1)
             .lean();
+
+        const hasNextPage = transactions.length > limit;
+        const trimmedTransactions = hasNextPage ? transactions.slice(0, -1) : transactions;
+        const nextCursor = hasNextPage
+            ? trimmedTransactions[trimmedTransactions.length - 1]?._id?.toString() ?? null
+            : null;
+
+        const summaryFilters = cursor ? filters.slice(0, -1) : filters;
+        const summaryMatch = summaryFilters.length > 1 ? { $and: summaryFilters } : summaryFilters[0];
+
+        const totals = await Transaction.aggregate([
+            {
+                $match: summaryMatch,
+            },
+            {
+                $group: {
+                    _id: '$type',
+                    total: { $sum: '$amount' },
+                },
+            },
+        ]);
+
+        const summary = totals.reduce(
+            (accumulator, item) => {
+                if (item._id === 'cash_in') {
+                    accumulator.income += item.total;
+                }
+                if (item._id === 'cash_out') {
+                    accumulator.expense += item.total;
+                }
+                return accumulator;
+            },
+            { income: 0, expense: 0 },
+        );
+
+        const balance = summary.income - summary.expense;
 
         res.status(200).json({
             project: mapProject(project),
-            transactions: transactions.map(mapTransaction),
+            transactions: trimmedTransactions.map(mapTransaction),
+            summary: {
+                income: summary.income,
+                expense: summary.expense,
+                balance,
+            },
+            pageInfo: {
+                hasNextPage,
+                nextCursor,
+                limit,
+            },
         });
     } catch (error) {
         next(error);
@@ -343,7 +569,68 @@ const deleteTransaction = async (req, res, next) => {
     }
 };
 
+const getProjectById = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId } = req.params;
+
+        if (!isValidObjectId(projectId)) {
+            return res.status(400).json({ message: 'Invalid project identifier.' });
+        }
+
+        const project = await Project.findOne({ _id: projectId, user_id: userId }).lean();
+
+        if (!project) {
+            return res.status(404).json({ message: 'Project not found.' });
+        }
+
+        const userIdentifier = toObjectIdOrNull(userId) ?? userId;
+
+        const totals = await Transaction.aggregate([
+            {
+                $match: {
+                    project_id: project._id,
+                    user_id: userIdentifier,
+                },
+            },
+            {
+                $group: {
+                    _id: '$type',
+                    total: { $sum: '$amount' },
+                },
+            },
+        ]);
+
+        const summary = totals.reduce(
+            (accumulator, item) => {
+                if (item._id === 'cash_in') {
+                    accumulator.income += item.total;
+                }
+                if (item._id === 'cash_out') {
+                    accumulator.expense += item.total;
+                }
+                return accumulator;
+            },
+            { income: 0, expense: 0 },
+        );
+
+        const balance = summary.income - summary.expense;
+
+        res.status(200).json({
+            project: mapProject(project),
+            summary: {
+                income: summary.income,
+                expense: summary.expense,
+                balance,
+            },
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
 module.exports = {
+    getProjectById,
     getProjects,
     createProject,
     updateProject,

--- a/server/routes/project.js
+++ b/server/routes/project.js
@@ -5,14 +5,30 @@ const { authenticate } = require('../middleware/authMiddleware');
 const {
     projectCreateValidationRules,
     projectUpdateValidationRules,
+    projectIdParamValidationRules,
+    projectListQueryValidationRules,
     transactionCreateValidationRules,
     transactionUpdateValidationRules,
+    transactionIdParamValidationRules,
+    transactionListValidationRules,
     handleValidationErrors,
 } = require('../validators/validatorsIndex');
 
 router.use(authenticate);
 
-router.get('/', projectController.getProjects);
+router.get(
+    '/',
+    projectListQueryValidationRules(),
+    handleValidationErrors,
+    projectController.getProjects,
+);
+
+router.get(
+    '/:projectId',
+    projectIdParamValidationRules(),
+    handleValidationErrors,
+    projectController.getProjectById,
+);
 
 router.post(
     '/',
@@ -30,11 +46,15 @@ router.put(
 
 router.delete(
     '/:projectId',
+    projectIdParamValidationRules(),
+    handleValidationErrors,
     projectController.deleteProject,
 );
 
 router.get(
     '/:projectId/transactions',
+    transactionListValidationRules(),
+    handleValidationErrors,
     projectController.getTransactions,
 );
 
@@ -54,6 +74,8 @@ router.put(
 
 router.delete(
     '/:projectId/transactions/:transactionId',
+    transactionIdParamValidationRules(),
+    handleValidationErrors,
     projectController.deleteTransaction,
 );
 

--- a/server/routes/project.js
+++ b/server/routes/project.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const router = express.Router();
+const projectController = require('../controllers/projectController');
+const { authenticate } = require('../middleware/authMiddleware');
+const {
+    projectCreateValidationRules,
+    projectUpdateValidationRules,
+    transactionCreateValidationRules,
+    transactionUpdateValidationRules,
+    handleValidationErrors,
+} = require('../validators/validatorsIndex');
+
+router.use(authenticate);
+
+router.get('/', projectController.getProjects);
+
+router.post(
+    '/',
+    projectCreateValidationRules(),
+    handleValidationErrors,
+    projectController.createProject,
+);
+
+router.put(
+    '/:projectId',
+    projectUpdateValidationRules(),
+    handleValidationErrors,
+    projectController.updateProject,
+);
+
+router.delete(
+    '/:projectId',
+    projectController.deleteProject,
+);
+
+router.get(
+    '/:projectId/transactions',
+    projectController.getTransactions,
+);
+
+router.post(
+    '/:projectId/transactions',
+    transactionCreateValidationRules(),
+    handleValidationErrors,
+    projectController.createTransaction,
+);
+
+router.put(
+    '/:projectId/transactions/:transactionId',
+    transactionUpdateValidationRules(),
+    handleValidationErrors,
+    projectController.updateTransaction,
+);
+
+router.delete(
+    '/:projectId/transactions/:transactionId',
+    projectController.deleteTransaction,
+);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ const userRoutes = require('./routes/user');
 const authRoutes = require('./routes/authRoutes');
 const planRoutes = require('./routes/plan');
 const adminUserRoutes = require('./routes/adminUsers');
+const projectRoutes = require('./routes/project');
 const { initializeEnforcer } = require('./services/casbin');
 const { scheduleSubscriptionExpiryCheck } = require('./jobs/subscriptionJobs');
 const AppError = require('./utils/AppError');
@@ -48,6 +49,7 @@ app.use('/api/users', userRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/plans', planRoutes);
 app.use('/api/admin/users', adminUserRoutes);
+app.use('/api/projects', projectRoutes);
 
 
 // Handle 404 Not Found for any routes not matched above

--- a/server/validators/projectValidators.js
+++ b/server/validators/projectValidators.js
@@ -1,4 +1,4 @@
-const { body, param } = require('express-validator');
+const { body, param, query } = require('express-validator');
 
 const projectCreateValidationRules = () => [
     body('name')
@@ -46,6 +46,29 @@ const projectUpdateValidationRules = () => [
             }
             return true;
         }),
+];
+
+const projectIdParamValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+];
+
+const projectListQueryValidationRules = () => [
+    query('search')
+        .optional()
+        .isString().withMessage('Search term must be a string.')
+        .trim()
+        .isLength({ max: 200 }).withMessage('Search term must be 200 characters or fewer.'),
+    query('sort')
+        .optional()
+        .isIn(['newest', 'oldest']).withMessage('Sort must be either "newest" or "oldest".'),
+    query('limit')
+        .optional()
+        .isInt({ min: 1, max: 100 }).withMessage('Limit must be between 1 and 100 records.')
+        .toInt(),
+    query('cursor')
+        .optional()
+        .isMongoId().withMessage('Cursor must be a valid identifier when provided.'),
 ];
 
 const transactionCreateValidationRules = () => [
@@ -112,9 +135,52 @@ const transactionUpdateValidationRules = () => [
         }),
 ];
 
+const transactionIdParamValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+    param('transactionId')
+        .isMongoId().withMessage('Invalid transaction identifier.'),
+];
+
+const transactionListValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+    query('limit')
+        .optional()
+        .isInt({ min: 1, max: 100 }).withMessage('Limit must be between 1 and 100 records.')
+        .toInt(),
+    query('cursor')
+        .optional()
+        .isMongoId().withMessage('Cursor must be a valid identifier when provided.'),
+    query('sort')
+        .optional()
+        .isIn(['newest', 'oldest']).withMessage('Sort must be either "newest" or "oldest".'),
+    query('type')
+        .optional()
+        .isIn(['income', 'expense']).withMessage('Type filter must be either "income" or "expense".')
+        .toLowerCase(),
+    query('search')
+        .optional()
+        .isString().withMessage('Search term must be a string.')
+        .trim()
+        .isLength({ max: 200 }).withMessage('Search term must be 200 characters or fewer.'),
+    query('startDate')
+        .optional()
+        .isISO8601().withMessage('startDate must be a valid ISO 8601 date.')
+        .trim(),
+    query('endDate')
+        .optional()
+        .isISO8601().withMessage('endDate must be a valid ISO 8601 date.')
+        .trim(),
+];
+
 module.exports = {
     projectCreateValidationRules,
     projectUpdateValidationRules,
+    projectIdParamValidationRules,
+    projectListQueryValidationRules,
     transactionCreateValidationRules,
     transactionUpdateValidationRules,
+    transactionIdParamValidationRules,
+    transactionListValidationRules,
 };

--- a/server/validators/projectValidators.js
+++ b/server/validators/projectValidators.js
@@ -1,0 +1,120 @@
+const { body, param } = require('express-validator');
+
+const projectCreateValidationRules = () => [
+    body('name')
+        .exists({ checkFalsy: true }).withMessage('Project name is required.')
+        .isString().withMessage('Project name must be a string.')
+        .trim()
+        .isLength({ min: 2, max: 120 }).withMessage('Project name must be between 2 and 120 characters.'),
+    body('description')
+        .optional()
+        .isString().withMessage('Description must be a string.')
+        .trim()
+        .isLength({ min: 5, max: 1024 }).withMessage('Description must be between 5 and 1024 characters.'),
+    body('currency')
+        .optional()
+        .isString().withMessage('Currency must be a string.')
+        .trim()
+        .isLength({ min: 3, max: 3 }).withMessage('Currency must be a 3-letter ISO code.')
+        .toUpperCase(),
+];
+
+const projectUpdateValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+    body('name')
+        .optional()
+        .isString().withMessage('Project name must be a string.')
+        .trim()
+        .isLength({ min: 2, max: 120 }).withMessage('Project name must be between 2 and 120 characters.'),
+    body('description')
+        .optional()
+        .isString().withMessage('Description must be a string.')
+        .trim()
+        .isLength({ min: 5, max: 1024 }).withMessage('Description must be between 5 and 1024 characters.'),
+    body('currency')
+        .optional()
+        .isString().withMessage('Currency must be a string.')
+        .trim()
+        .isLength({ min: 3, max: 3 }).withMessage('Currency must be a 3-letter ISO code.')
+        .toUpperCase(),
+    body()
+        .custom((value, { req }) => {
+            const provided = Object.keys(req.body || {});
+            if (provided.length === 0) {
+                throw new Error('At least one field must be provided for update.');
+            }
+            return true;
+        }),
+];
+
+const transactionCreateValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+    body('date')
+        .exists({ checkFalsy: true }).withMessage('Transaction date is required.')
+        .isISO8601().withMessage('Transaction date must be a valid ISO 8601 date.')
+        .trim(),
+    body('type')
+        .exists({ checkFalsy: true }).withMessage('Transaction type is required.')
+        .isIn(['income', 'expense']).withMessage('Transaction type must be either "income" or "expense".')
+        .toLowerCase(),
+    body('amount')
+        .exists({ checkFalsy: true }).withMessage('Amount is required.')
+        .isFloat({ gt: 0 }).withMessage('Amount must be greater than zero.')
+        .toFloat(),
+    body('subcategory')
+        .exists({ checkFalsy: true }).withMessage('Subcategory is required.')
+        .isString().withMessage('Subcategory must be a string.')
+        .trim()
+        .isLength({ min: 2, max: 120 }).withMessage('Subcategory must be between 2 and 120 characters.'),
+    body('description')
+        .exists({ checkFalsy: true }).withMessage('Description is required.')
+        .isString().withMessage('Description must be a string.')
+        .trim()
+        .isLength({ min: 3, max: 1024 }).withMessage('Description must be between 3 and 1024 characters.'),
+];
+
+const transactionUpdateValidationRules = () => [
+    param('projectId')
+        .isMongoId().withMessage('Invalid project identifier.'),
+    param('transactionId')
+        .isMongoId().withMessage('Invalid transaction identifier.'),
+    body('date')
+        .optional()
+        .isISO8601().withMessage('Transaction date must be a valid ISO 8601 date.')
+        .trim(),
+    body('type')
+        .optional()
+        .isIn(['income', 'expense']).withMessage('Transaction type must be either "income" or "expense".')
+        .toLowerCase(),
+    body('amount')
+        .optional()
+        .isFloat({ gt: 0 }).withMessage('Amount must be greater than zero.')
+        .toFloat(),
+    body('subcategory')
+        .optional()
+        .isString().withMessage('Subcategory must be a string.')
+        .trim()
+        .isLength({ min: 2, max: 120 }).withMessage('Subcategory must be between 2 and 120 characters.'),
+    body('description')
+        .optional()
+        .isString().withMessage('Description must be a string.')
+        .trim()
+        .isLength({ min: 3, max: 1024 }).withMessage('Description must be between 3 and 1024 characters.'),
+    body()
+        .custom((value, { req }) => {
+            const provided = Object.keys(req.body || {});
+            if (provided.length === 0) {
+                throw new Error('At least one field must be provided for update.');
+            }
+            return true;
+        }),
+];
+
+module.exports = {
+    projectCreateValidationRules,
+    projectUpdateValidationRules,
+    transactionCreateValidationRules,
+    transactionUpdateValidationRules,
+};

--- a/server/validators/validatorsIndex.js
+++ b/server/validators/validatorsIndex.js
@@ -54,7 +54,11 @@ module.exports = {
     changePlanValidationRules: planValidators.changePlanValidationRules,
     projectCreateValidationRules: projectValidators.projectCreateValidationRules,
     projectUpdateValidationRules: projectValidators.projectUpdateValidationRules,
+    projectIdParamValidationRules: projectValidators.projectIdParamValidationRules,
+    projectListQueryValidationRules: projectValidators.projectListQueryValidationRules,
     transactionCreateValidationRules: projectValidators.transactionCreateValidationRules,
     transactionUpdateValidationRules: projectValidators.transactionUpdateValidationRules,
+    transactionIdParamValidationRules: projectValidators.transactionIdParamValidationRules,
+    transactionListValidationRules: projectValidators.transactionListValidationRules,
     handleValidationErrors,
 };

--- a/server/validators/validatorsIndex.js
+++ b/server/validators/validatorsIndex.js
@@ -2,6 +2,7 @@
 const authValidators = require('./authValidators');
 const paymentValidators = require('./paymentValidators');
 const planValidators = require('./planValidators');
+const projectValidators = require('./projectValidators');
 
 /**
  * Middleware to handle validation results.
@@ -51,5 +52,9 @@ module.exports = {
     planValidationRules: planValidators.planValidationRules,
     planValidationSlugOnlyRules: planValidators.planValidationSlugOnlyRules,
     changePlanValidationRules: planValidators.changePlanValidationRules,
+    projectCreateValidationRules: projectValidators.projectCreateValidationRules,
+    projectUpdateValidationRules: projectValidators.projectUpdateValidationRules,
+    transactionCreateValidationRules: projectValidators.transactionCreateValidationRules,
+    transactionUpdateValidationRules: projectValidators.transactionUpdateValidationRules,
     handleValidationErrors,
 };


### PR DESCRIPTION
## Summary
- add controller logic to manage project CRUD and project transaction CRUD with ownership validation
- introduce express-validator rules and routes for the new project endpoints
- register the project routes with the main Express server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0e637f7d8832ea3a33adce3c5635e