### PR TITLE
Integrate projects page with backend API

### DIFF
--- a/client/src/components/features/projects/project-list.js
+++ b/client/src/components/features/projects/project-list.js
@@ -1,7 +1,6 @@
 // File: src/components/features/projects/project-list.js
 "use client";
 
-import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -12,34 +11,28 @@ import { cn } from "@/lib/utils";
 export default function ProjectList({
   projects = [],
   isLoading,
+  isLoadingMore,
+  hasNextPage,
   selectedProjectId,
   onSelect,
   onAddProject,
   onEditProject,
   onDeleteProject,
+  onLoadMore,
+  searchValue = "",
+  sortValue = "newest",
+  onSearchChange,
+  onSortChange,
 }) {
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState("newest");
+  const displayProjects = Array.isArray(projects) ? projects : [];
 
-  const filteredProjects = useMemo(() => {
-    const normalizedSearch = search.trim().toLowerCase();
-    const getTimestamp = (value) => {
-      if (!value) return 0;
-      const parsed = new Date(value).getTime();
-      return Number.isFinite(parsed) ? parsed : 0;
-    };
+  const handleSearchChange = (event) => {
+    onSearchChange?.(event.target.value);
+  };
 
-    return projects
-      .filter((project) => {
-        const name = typeof project?.name === "string" ? project.name : "";
-        return name.toLowerCase().includes(normalizedSearch);
-      })
-      .sort((a, b) => {
-        const aTime = getTimestamp(a?.createdAt);
-        const bTime = getTimestamp(b?.createdAt);
-        return sort === "newest" ? bTime - aTime : aTime - bTime;
-      });
-  }, [projects, search, sort]);
+  const handleSortChange = (value) => {
+    onSortChange?.(value);
+  };
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -60,13 +53,13 @@ export default function ProjectList({
           <Input
             id="project-search"
             placeholder="Search by name"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
+            value={searchValue}
+            onChange={handleSearchChange}
           />
         </div>
         <div className="grid gap-2">
           <Label className="text-xs uppercase tracking-wide text-muted-foreground">Sort by</Label>
-          <Select value={sort} onValueChange={setSort}>
+          <Select value={sortValue} onValueChange={handleSortChange}>
             <SelectTrigger>
               <SelectValue placeholder="Sort projects" />
             </SelectTrigger>
@@ -84,8 +77,8 @@ export default function ProjectList({
               <div key={index} className="h-20 animate-pulse rounded-lg bg-muted" />
             ))}
           </div>
-        ) : filteredProjects.length ? (
-          filteredProjects.map((project, index) => {
+        ) : displayProjects.length ? (
+          displayProjects.map((project, index) => {
             const projectId = project?.id;
             const projectName = typeof project?.name === "string" && project.name.trim().length ? project.name : "Untitled project";
             const projectDescription =
@@ -164,6 +157,16 @@ export default function ProjectList({
           <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
             No projects created yet. Click “Add New Project” to start.
           </div>
+        )}
+        {hasNextPage && (
+          <Button
+            variant="outline"
+            className="mt-2 w-full"
+            onClick={onLoadMore}
+            disabled={isLoadingMore}
+          >
+            {isLoadingMore ? "Loading..." : "Load more"}
+          </Button>
         )}
       </div>
       <div className="sticky bottom-4 md:hidden">

--- a/client/src/hooks/use-debounced-value.js
+++ b/client/src/hooks/use-debounced-value.js
@@ -1,0 +1,16 @@
+// File: src/hooks/use-debounced-value.js
+import { useEffect, useState } from "react";
+
+// Simple hook that returns a debounced version of the provided value.
+export function useDebouncedValue(value, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebouncedValue;

--- a/client/src/lib/queries/projects.js
+++ b/client/src/lib/queries/projects.js
@@ -1,0 +1,171 @@
+// File: src/lib/queries/projects.js
+import { apiJSON } from "@/lib/api";
+
+const PROJECTS_ENDPOINT = "/api/projects";
+
+const buildQueryString = (params = {}) => {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") return;
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : "";
+};
+
+const normalizeProject = (project) => {
+  if (!project || typeof project !== "object") {
+    return null;
+  }
+
+  return {
+    id: project.id ?? "",
+    name: project.name ?? "",
+    description: project.description ?? "",
+    currency: project.currency ?? "",
+    createdAt: project.createdAt ?? null,
+    updatedAt: project.updatedAt ?? null,
+  };
+};
+
+const normalizeTransaction = (transaction) => {
+  if (!transaction || typeof transaction !== "object") {
+    return null;
+  }
+
+  return {
+    id: transaction.id ?? "",
+    projectId: transaction.projectId ?? "",
+    date: transaction.date ?? null,
+    type: transaction.type ?? "Expense",
+    amount: transaction.amount ?? 0,
+    subcategory: transaction.subcategory ?? "",
+    description: transaction.description ?? "",
+    createdAt: transaction.createdAt ?? null,
+    updatedAt: transaction.updatedAt ?? null,
+  };
+};
+
+const mapProjectInput = (input = {}) => ({
+  name: input.name?.trim() ?? "",
+  description: input.description?.trim() ?? "",
+  currency: input.currency?.trim() ?? undefined,
+});
+
+const mapTransactionInput = (input = {}) => ({
+  date: input.date,
+  type: input.type,
+  amount: input.amount,
+  subcategory: input.subcategory?.trim() ?? "",
+  description: input.description?.trim() ?? "",
+});
+
+export async function listProjects({ search, sort, limit, cursor, signal } = {}) {
+  const queryString = buildQueryString({ search, sort, limit, cursor });
+  const response = await apiJSON(`${PROJECTS_ENDPOINT}${queryString}`, { method: "GET", signal });
+
+  const projects = Array.isArray(response?.projects)
+    ? response.projects.map(normalizeProject).filter(Boolean)
+    : [];
+
+  const pageInfo = {
+    hasNextPage: Boolean(response?.pageInfo?.hasNextPage),
+    nextCursor: response?.pageInfo?.nextCursor ?? null,
+    limit: response?.pageInfo?.limit ?? limit ?? 20,
+  };
+
+  const totalCount = typeof response?.totalCount === "number" ? response.totalCount : projects.length;
+
+  return { projects, pageInfo, totalCount };
+}
+
+export async function listProjectTransactions({
+  projectId,
+  search,
+  sort,
+  limit,
+  cursor,
+  signal,
+} = {}) {
+  if (!projectId) {
+    throw new Error("projectId is required to load transactions");
+  }
+
+  const queryString = buildQueryString({ search, sort, limit, cursor });
+  const response = await apiJSON(`${PROJECTS_ENDPOINT}/${projectId}/transactions${queryString}`, {
+    method: "GET",
+    signal,
+  });
+
+  const transactions = Array.isArray(response?.transactions)
+    ? response.transactions.map(normalizeTransaction).filter(Boolean)
+    : [];
+
+  const pageInfo = {
+    hasNextPage: Boolean(response?.pageInfo?.hasNextPage),
+    nextCursor: response?.pageInfo?.nextCursor ?? null,
+    limit: response?.pageInfo?.limit ?? limit ?? 20,
+  };
+
+  const summary = {
+    income: Number(response?.summary?.income) || 0,
+    expense: Number(response?.summary?.expense) || 0,
+    balance: Number(response?.summary?.balance) || 0,
+  };
+
+  const project = response?.project ? normalizeProject(response.project) : null;
+
+  return { project, transactions, summary, pageInfo };
+}
+
+export async function createProject(input, { signal } = {}) {
+  const body = mapProjectInput(input);
+  return apiJSON(PROJECTS_ENDPOINT, { method: "POST", body, signal });
+}
+
+export async function updateProject({ projectId, ...input }, { signal } = {}) {
+  if (!projectId) {
+    throw new Error("projectId is required to update a project");
+  }
+  const body = mapProjectInput(input);
+  return apiJSON(`${PROJECTS_ENDPOINT}/${projectId}`, { method: "PUT", body, signal });
+}
+
+export async function deleteProject({ projectId }, { signal } = {}) {
+  if (!projectId) {
+    throw new Error("projectId is required to delete a project");
+  }
+  return apiJSON(`${PROJECTS_ENDPOINT}/${projectId}`, { method: "DELETE", signal });
+}
+
+export async function createTransaction({ projectId, ...input }, { signal } = {}) {
+  if (!projectId) {
+    throw new Error("projectId is required to create a transaction");
+  }
+  const body = mapTransactionInput(input);
+  return apiJSON(`${PROJECTS_ENDPOINT}/${projectId}/transactions`, { method: "POST", body, signal });
+}
+
+export async function updateTransaction({ projectId, transactionId, ...input }, { signal } = {}) {
+  if (!projectId || !transactionId) {
+    throw new Error("projectId and transactionId are required to update a transaction");
+  }
+  const body = mapTransactionInput(input);
+  return apiJSON(`${PROJECTS_ENDPOINT}/${projectId}/transactions/${transactionId}`, {
+    method: "PUT",
+    body,
+    signal,
+  });
+}
+
+export async function deleteTransaction({ projectId, transactionId }, { signal } = {}) {
+  if (!projectId || !transactionId) {
+    throw new Error("projectId and transactionId are required to delete a transaction");
+  }
+  return apiJSON(`${PROJECTS_ENDPOINT}/${projectId}/transactions/${transactionId}`, {
+    method: "DELETE",
+    signal,
+  });
+}

--- a/client/src/lib/query-keys.js
+++ b/client/src/lib/query-keys.js
@@ -1,4 +1,18 @@
 // File: src/lib/query-keys.js
+const normalizeParams = (params) => {
+  if (!params || typeof params !== "object") {
+    return {};
+  }
+
+  return Object.keys(params)
+    .filter((key) => params[key] !== undefined)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = params[key];
+      return acc;
+    }, {});
+};
+
 export const qk = {
   orders: {
     list: (params) => ["orders", "list", params || {}],
@@ -13,8 +27,8 @@ export const qk = {
     recentTransactions: () => ["dashboard", "recent-transactions"],
   },
   projects: {
-    list: () => ["projects", "list"],
-    detail: (id) => ["projects", "detail", String(id)],
+    list: (params) => ["projects", "list", normalizeParams(params)],
+    detail: (id, params) => ["projects", "detail", String(id), normalizeParams(params)],
   },
   reports: {
     filters: () => ["reports", "filters"],


### PR DESCRIPTION
## Summary
- replace the projects workspace mock data with TanStack Query integrations that call the real project and transaction APIs, including cursor pagination and optimistic mutations
- add reusable query helpers and a debounced value hook to coordinate server-driven search and pagination
- update the projects list and transaction table components to use controlled filters and show load-more pagination

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1071e9184832ea3fcc65d02b60ef5