### PR TITLE
Add summary reporting endpoints and helpers

### DIFF
--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -366,24 +366,6 @@ const getTransactions = async (req, res, next) => {
     }
 };
 
-const toStorageType = (type) => {
-    if (type === 'income') {
-        return 'cash_in';
-    }
-    if (type === 'expense') {
-        return 'cash_out';
-    }
-    return null;
-};
-
-const parseTransactionDate = (value) => {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return null;
-    }
-    return date;
-};
-
 const createTransaction = async (req, res, next) => {
     try {
         const userId = req.user?._id;

--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -1,33 +1,17 @@
-const mongoose = require('mongoose');
 const Project = require('../models/Project');
 const Transaction = require('../models/Transaction');
 
-const { Types } = mongoose;
-
-const isValidObjectId = (value) => Types.ObjectId.isValid(value);
-
-const escapeRegex = (value = '') => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const clampLimit = (value, { min = 1, max = 100, defaultValue = 20 } = {}) => {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isFinite(parsed)) {
-        return defaultValue;
-    }
-    return Math.min(Math.max(parsed, min), max);
-};
-
-const toObjectIdOrNull = (value) => {
-    if (!value) {
-        return null;
-    }
-    if (value instanceof Types.ObjectId) {
-        return value;
-    }
-    if (typeof value === 'string' && Types.ObjectId.isValid(value)) {
-        return new Types.ObjectId(value);
-    }
-    return null;
-};
+const {
+    clampLimit,
+    escapeRegex,
+    toObjectIdOrNull,
+    isValidObjectId,
+    toResponseDate,
+    mapTransaction,
+    buildTransactionCursorFilter,
+    toStorageType,
+    parseTransactionDate,
+} = require('../utils/transactionQueryHelpers');
 
 const mapProject = (project) => ({
     id: project._id.toString(),
@@ -36,29 +20,6 @@ const mapProject = (project) => ({
     currency: project.currency,
     createdAt: toResponseDate(project.createdAt),
     updatedAt: project.updatedAt ? project.updatedAt.toISOString() : null,
-});
-
-const toResponseDate = (date) => {
-    if (!date) {
-        return null;
-    }
-    try {
-        return date.toISOString().slice(0, 10);
-    } catch (error) {
-        return null;
-    }
-};
-
-const mapTransaction = (transaction) => ({
-    id: transaction._id.toString(),
-    projectId: transaction.project_id.toString(),
-    date: toResponseDate(transaction.transaction_date),
-    type: transaction.type === 'cash_out' ? 'Expense' : 'Income',
-    amount: transaction.amount,
-    subcategory: transaction.subcategory,
-    description: transaction.description || '',
-    createdAt: transaction.createdAt ? transaction.createdAt.toISOString() : null,
-    updatedAt: transaction.updatedAt ? transaction.updatedAt.toISOString() : null,
 });
 
 const ensureProjectOwnership = async (projectId, userId) => {
@@ -84,25 +45,6 @@ const buildCursorFilter = (direction, fieldName, fieldValue, idValue) => {
             {
                 [fieldName]: fieldValue,
                 _id: { [equalityOperator]: idValue },
-            },
-        ],
-    };
-};
-
-const buildTransactionCursorFilter = (direction, cursorDoc) => {
-    if (!cursorDoc?.transaction_date) {
-        return {};
-    }
-
-    const comparisonOperator = direction === 1 ? '$gt' : '$lt';
-    const equalityOperator = direction === 1 ? '$gt' : '$lt';
-
-    return {
-        $or: [
-            { transaction_date: { [comparisonOperator]: cursorDoc.transaction_date } },
-            {
-                transaction_date: cursorDoc.transaction_date,
-                _id: { [equalityOperator]: cursorDoc._id },
             },
         ],
     };

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+
+const reportController = require('../controllers/reportController');
+const { authenticate } = require('../middleware/authMiddleware');
+const {
+    summaryListValidationRules,
+    handleValidationErrors,
+} = require('../validators/validatorsIndex');
+
+router.use(authenticate);
+
+router.get(
+    '/summary',
+    summaryListValidationRules(),
+    handleValidationErrors,
+    reportController.getSummary,
+);
+
+router.get('/summary/filters', reportController.getSummaryFilters);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ const authRoutes = require('./routes/authRoutes');
 const planRoutes = require('./routes/plan');
 const adminUserRoutes = require('./routes/adminUsers');
 const projectRoutes = require('./routes/project');
+const reportRoutes = require('./routes/report');
 const { initializeEnforcer } = require('./services/casbin');
 const { scheduleSubscriptionExpiryCheck } = require('./jobs/subscriptionJobs');
 const AppError = require('./utils/AppError');
@@ -50,6 +51,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/plans', planRoutes);
 app.use('/api/admin/users', adminUserRoutes);
 app.use('/api/projects', projectRoutes);
+app.use('/api/reports', reportRoutes);
 
 
 // Handle 404 Not Found for any routes not matched above

--- a/server/utils/transactionQueryHelpers.js
+++ b/server/utils/transactionQueryHelpers.js
@@ -1,0 +1,128 @@
+const mongoose = require('mongoose');
+
+const { Types } = mongoose;
+
+const clampLimit = (value, { min = 1, max = 100, defaultValue = 20 } = {}) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+        return defaultValue;
+    }
+    return Math.min(Math.max(parsed, min), max);
+};
+
+const escapeRegex = (value = '') => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const toObjectIdOrNull = (value) => {
+    if (!value) {
+        return null;
+    }
+    if (value instanceof Types.ObjectId) {
+        return value;
+    }
+    if (typeof value === 'string' && Types.ObjectId.isValid(value)) {
+        return new Types.ObjectId(value);
+    }
+    return null;
+};
+
+const isValidObjectId = (value) => Types.ObjectId.isValid(value);
+
+const toResponseDate = (date) => {
+    if (!date) {
+        return null;
+    }
+    try {
+        return date.toISOString().slice(0, 10);
+    } catch (error) {
+        return null;
+    }
+};
+
+const extractProjectReference = (project) => {
+    if (!project) {
+        return { projectId: '', projectName: null };
+    }
+
+    if (typeof project === 'string') {
+        return { projectId: project, projectName: null };
+    }
+
+    if (project instanceof Types.ObjectId) {
+        return { projectId: project.toString(), projectName: null };
+    }
+
+    if (typeof project === 'object') {
+        const identifier = project._id || project.id || project;
+        const projectId = identifier ? identifier.toString() : '';
+        const projectName = typeof project.name === 'string' ? project.name : null;
+        return { projectId, projectName };
+    }
+
+    return { projectId: '', projectName: null };
+};
+
+const mapTransaction = (transaction) => {
+    const { projectId, projectName } = extractProjectReference(transaction.project_id);
+
+    return {
+        id: transaction._id ? transaction._id.toString() : '',
+        projectId,
+        projectName,
+        date: toResponseDate(transaction.transaction_date),
+        type: transaction.type === 'cash_out' ? 'Expense' : 'Income',
+        amount: transaction.amount,
+        subcategory: transaction.subcategory,
+        description: transaction.description || '',
+        createdAt: transaction.createdAt ? transaction.createdAt.toISOString() : null,
+        updatedAt: transaction.updatedAt ? transaction.updatedAt.toISOString() : null,
+    };
+};
+
+const buildTransactionCursorFilter = (direction, cursorDoc) => {
+    if (!cursorDoc?.transaction_date) {
+        return {};
+    }
+
+    const comparisonOperator = direction === 1 ? '$gt' : '$lt';
+    const equalityOperator = direction === 1 ? '$gt' : '$lt';
+
+    return {
+        $or: [
+            { transaction_date: { [comparisonOperator]: cursorDoc.transaction_date } },
+            {
+                transaction_date: cursorDoc.transaction_date,
+                _id: { [equalityOperator]: cursorDoc._id },
+            },
+        ],
+    };
+};
+
+const toStorageType = (type) => {
+    if (type === 'income') {
+        return 'cash_in';
+    }
+    if (type === 'expense') {
+        return 'cash_out';
+    }
+    return null;
+};
+
+const parseTransactionDate = (value) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    return date;
+};
+
+module.exports = {
+    clampLimit,
+    escapeRegex,
+    toObjectIdOrNull,
+    isValidObjectId,
+    toResponseDate,
+    mapTransaction,
+    buildTransactionCursorFilter,
+    toStorageType,
+    parseTransactionDate,
+};

--- a/server/validators/reportValidators.js
+++ b/server/validators/reportValidators.js
@@ -1,0 +1,38 @@
+const { query } = require('express-validator');
+
+const summaryListValidationRules = () => [
+    query('limit')
+        .optional()
+        .isInt({ min: 1, max: 100 }).withMessage('Limit must be between 1 and 100 records.')
+        .toInt(),
+    query('cursor')
+        .optional()
+        .isMongoId().withMessage('Cursor must be a valid identifier when provided.'),
+    query('sort')
+        .optional()
+        .isIn(['newest', 'oldest']).withMessage('Sort must be either "newest" or "oldest".'),
+    query('type')
+        .optional()
+        .isIn(['income', 'expense']).withMessage('Type filter must be either "income" or "expense".')
+        .toLowerCase(),
+    query('projectId')
+        .optional()
+        .isMongoId().withMessage('projectId must be a valid identifier when provided.'),
+    query('search')
+        .optional()
+        .isString().withMessage('Search term must be a string.')
+        .trim()
+        .isLength({ max: 200 }).withMessage('Search term must be 200 characters or fewer.'),
+    query('startDate')
+        .optional()
+        .isISO8601().withMessage('startDate must be a valid ISO 8601 date.')
+        .trim(),
+    query('endDate')
+        .optional()
+        .isISO8601().withMessage('endDate must be a valid ISO 8601 date.')
+        .trim(),
+];
+
+module.exports = {
+    summaryListValidationRules,
+};

--- a/server/validators/validatorsIndex.js
+++ b/server/validators/validatorsIndex.js
@@ -3,6 +3,7 @@ const authValidators = require('./authValidators');
 const paymentValidators = require('./paymentValidators');
 const planValidators = require('./planValidators');
 const projectValidators = require('./projectValidators');
+const reportValidators = require('./reportValidators');
 
 /**
  * Middleware to handle validation results.
@@ -60,5 +61,6 @@ module.exports = {
     transactionUpdateValidationRules: projectValidators.transactionUpdateValidationRules,
     transactionIdParamValidationRules: projectValidators.transactionIdParamValidationRules,
     transactionListValidationRules: projectValidators.transactionListValidationRules,
+    summaryListValidationRules: reportValidators.summaryListValidationRules,
     handleValidationErrors,
 };


### PR DESCRIPTION
## Summary
- add shared transaction query helpers and update the project controller to consume them
- implement `/api/reports/summary` with filtering, cursor pagination, totals, and per-project aggregates for the summary view
- expose report validators and routes, including a filters endpoint for client dropdowns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e22d738554832ea1b5f09bee3640f4