### PR TITLE
Integrate summary page with backend report APIs

### DIFF
--- a/client/src/app/(user)/summary/page.js
+++ b/client/src/app/(user)/summary/page.js
@@ -1,36 +1,98 @@
 // File: src/app/(user)/summary/page.js
 "use client";
 
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import PageHeader from "@/components/shared/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { qk } from "@/lib/query-keys";
-import { fetchSummaryTable } from "@/lib/mock-data";
+import { fetchSummaryFilters, fetchSummaryReport } from "@/lib/queries/reports";
+
+const PAGE_SIZE = 20;
 
 // Summary view combining filters with a tabular report.
 export default function SummaryPage() {
-  const { data = [], isLoading } = useQuery({ queryKey: qk.reports.summaryTable(), queryFn: fetchSummaryTable });
+  const { data: filtersData, isLoading: filtersLoading } = useQuery({
+    queryKey: qk.reports.filters(),
+    queryFn: fetchSummaryFilters,
+  });
   const [projectFilter, setProjectFilter] = useState("all");
   const [typeFilter, setTypeFilter] = useState("all");
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
 
-  const projects = useMemo(() => Array.from(new Set(data.map((item) => item.projectId))), [data]);
+  useEffect(() => {
+    if (!filtersData?.projects?.length || projectFilter === "all") {
+      return;
+    }
 
-  const filtered = useMemo(() => {
-    return data.filter((item) => {
-      const matchesProject = projectFilter === "all" || item.projectId === projectFilter;
-      const matchesType = typeFilter === "all" || item.type.toLowerCase() === typeFilter;
-      const matchesFrom = !from || new Date(item.date) >= new Date(from);
-      const matchesTo = !to || new Date(item.date) <= new Date(to);
-      return matchesProject && matchesType && matchesFrom && matchesTo;
-    });
-  }, [data, projectFilter, typeFilter, from, to]);
+    const exists = filtersData.projects.some((project) => project.value === projectFilter);
+    if (!exists) {
+      setProjectFilter("all");
+    }
+  }, [filtersData?.projects, projectFilter]);
+
+  const filtersKey = useMemo(() => ({
+    projectId: projectFilter !== "all" ? projectFilter : undefined,
+    type: typeFilter !== "all" ? typeFilter : undefined,
+    startDate: from || undefined,
+    endDate: to || undefined,
+  }), [projectFilter, typeFilter, from, to]);
+
+  const isDateRangeInvalid = useMemo(() => {
+    if (!from || !to) {
+      return false;
+    }
+    const start = new Date(from);
+    const end = new Date(to);
+    return Number.isFinite(start.getTime()) && Number.isFinite(end.getTime()) && start > end;
+  }, [from, to]);
+
+  const summaryQuery = useInfiniteQuery({
+    queryKey: qk.reports.summaryTable(filtersKey),
+    queryFn: ({ pageParam, signal }) =>
+      fetchSummaryReport({
+        ...filtersKey,
+        cursor: pageParam?.cursor,
+        limit: PAGE_SIZE,
+        signal,
+      }),
+    initialPageParam: { cursor: undefined },
+    getNextPageParam: (lastPage) => {
+      if (!lastPage?.pageInfo?.hasNextPage) {
+        return undefined;
+      }
+      return { cursor: lastPage.pageInfo.nextCursor ?? undefined };
+    },
+    enabled: !isDateRangeInvalid,
+    staleTime: 30_000,
+  });
+
+  const transactions = useMemo(() => {
+    const pages = summaryQuery.data?.pages ?? [];
+    return pages.flatMap((page) => page.transactions ?? []);
+  }, [summaryQuery.data]);
+
+  const summaryPages = summaryQuery.data?.pages ?? [];
+  const latestSummary = summaryPages.length ? summaryPages[summaryPages.length - 1]?.summary : null;
+  const summaryTotals = latestSummary ?? { income: 0, expense: 0, balance: 0, counts: { income: 0, expense: 0, total: 0 } };
+  const summaryCounts = summaryTotals.counts ?? { income: 0, expense: 0, total: 0 };
+  const totalCount = summaryPages.length ? summaryPages[0]?.totalCount ?? 0 : 0;
+
+  const hasTransactions = transactions.length > 0;
+  const isInitialLoading = summaryQuery.isLoading;
+  const isRefetching = summaryQuery.isRefetching;
+  const isFetchingNextPage = summaryQuery.isFetchingNextPage;
+  const hasNextPage = Boolean(summaryQuery.hasNextPage);
+  const errorMessage = summaryQuery.error?.body?.message || summaryQuery.error?.message;
+
+  const projectOptions = filtersData?.projects ?? [];
+  const typeOptions = filtersData?.transactionTypes ?? [];
 
   return (
     <div className="space-y-8">
@@ -45,15 +107,15 @@ export default function SummaryPage() {
         <CardContent className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <div className="grid gap-2">
             <Label>Project</Label>
-            <Select value={projectFilter} onValueChange={setProjectFilter}>
+            <Select value={projectFilter} onValueChange={setProjectFilter} disabled={filtersLoading}>
               <SelectTrigger>
                 <SelectValue placeholder="All projects" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All projects</SelectItem>
-                {projects.map((project) => (
-                  <SelectItem key={project} value={project}>
-                    {project}
+                {projectOptions.map((project) => (
+                  <SelectItem key={project.value} value={project.value}>
+                    {project.label || project.name || project.value}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -61,14 +123,17 @@ export default function SummaryPage() {
           </div>
           <div className="grid gap-2">
             <Label>Type</Label>
-            <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <Select value={typeFilter} onValueChange={setTypeFilter} disabled={filtersLoading}>
               <SelectTrigger>
                 <SelectValue placeholder="All types" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All</SelectItem>
-                <SelectItem value="income">Income</SelectItem>
-                <SelectItem value="expense">Expense</SelectItem>
+                {typeOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
@@ -84,42 +149,92 @@ export default function SummaryPage() {
       </Card>
       <Card>
         <CardHeader>
-          <CardTitle>Transactions</CardTitle>
+          <CardTitle>Totals</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="space-y-1 rounded-lg border p-4">
+            <p className="text-sm text-muted-foreground">Income</p>
+            <p className="text-2xl font-semibold">${summaryTotals.income.toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground">{summaryCounts.income} income transactions</p>
+          </div>
+          <div className="space-y-1 rounded-lg border p-4">
+            <p className="text-sm text-muted-foreground">Expenses</p>
+            <p className="text-2xl font-semibold">${summaryTotals.expense.toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground">{summaryCounts.expense} expense transactions</p>
+          </div>
+          <div className="space-y-1 rounded-lg border p-4 lg:col-span-1">
+            <p className="text-sm text-muted-foreground">Net balance</p>
+            <p className="text-2xl font-semibold">${summaryTotals.balance.toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground">{summaryCounts.total} total transactions</p>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="space-y-1 sm:flex sm:items-center sm:justify-between sm:space-y-0">
+          <div>
+            <CardTitle>Transactions</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {isInitialLoading
+                ? "Loading transactions..."
+                : `Showing ${transactions.length.toLocaleString()} of ${totalCount.toLocaleString()} transactions`}
+            </p>
+          </div>
         </CardHeader>
         <CardContent>
-          {isLoading ? (
+          {isDateRangeInvalid ? (
+            <p className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+              Start date cannot be later than end date.
+            </p>
+          ) : isInitialLoading ? (
             <div className="space-y-3">
               {Array.from({ length: 6 }).map((_, index) => (
                 <div key={index} className="h-10 animate-pulse rounded-md bg-muted" />
               ))}
             </div>
           ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Date</TableHead>
-                    <TableHead>Project</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Category</TableHead>
-                    <TableHead className="text-right">Amount</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filtered.map((item) => (
-                    <TableRow key={item.id}>
-                      <TableCell>{item.date}</TableCell>
-                      <TableCell>{item.projectId}</TableCell>
-                      <TableCell>{item.type}</TableCell>
-                      <TableCell>{item.category}</TableCell>
-                      <TableCell className="text-right font-medium">${item.amount.toLocaleString()}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-              {!filtered.length && (
-                <p className="p-4 text-sm text-muted-foreground">No transactions match the selected filters.</p>
+            <div className="space-y-3">
+              {summaryQuery.isError && (
+                <p className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+                  {errorMessage || "Unable to load transactions."}
+                </p>
               )}
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Project</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Category</TableHead>
+                      <TableHead className="text-right">Amount</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {transactions.map((item) => (
+                      <TableRow key={item.id}>
+                        <TableCell>{item.date}</TableCell>
+                        <TableCell>{item.projectName || item.projectId || "--"}</TableCell>
+                        <TableCell>{item.type}</TableCell>
+                        <TableCell>{item.category || "--"}</TableCell>
+                        <TableCell className="text-right font-medium">${item.amount.toLocaleString()}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                {!hasTransactions && !isRefetching && !summaryQuery.isError && (
+                  <p className="p-4 text-sm text-muted-foreground">No transactions match the selected filters.</p>
+                )}
+                {isRefetching && !isInitialLoading && (
+                  <div className="p-4 text-sm text-muted-foreground">Updating results…</div>
+                )}
+                {hasNextPage && (
+                  <div className="mt-4 flex justify-center">
+                    <Button onClick={() => summaryQuery.fetchNextPage()} disabled={isFetchingNextPage}>
+                      {isFetchingNextPage ? "Loading more..." : "Load more"}
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </CardContent>

--- a/client/src/lib/queries/reports.js
+++ b/client/src/lib/queries/reports.js
@@ -1,0 +1,159 @@
+// File: src/lib/queries/reports.js
+import { apiJSON } from "@/lib/api";
+
+const REPORTS_BASE = "/api/reports";
+const SUMMARY_ENDPOINT = `${REPORTS_BASE}/summary`;
+const SUMMARY_FILTERS_ENDPOINT = `${SUMMARY_ENDPOINT}/filters`;
+
+const buildQueryString = (params = {}) => {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") return;
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : "";
+};
+
+const normalizeTransaction = (transaction) => {
+  if (!transaction || typeof transaction !== "object") {
+    return null;
+  }
+
+  return {
+    id: transaction.id ?? "",
+    projectId: transaction.projectId ?? "",
+    projectName: transaction.projectName ?? null,
+    date: transaction.date ?? null,
+    type: transaction.type ?? "Expense",
+    category: transaction.category ?? "",
+    amount: Number(transaction.amount) || 0,
+    description: transaction.description ?? "",
+  };
+};
+
+const normalizeSummary = (summary) => {
+  const income = Number(summary?.income) || 0;
+  const expense = Number(summary?.expense) || 0;
+  const balance = Number(summary?.balance) || income - expense;
+  const counts = summary?.counts ?? {};
+
+  return {
+    income,
+    expense,
+    balance,
+    counts: {
+      income: Number(counts.income) || 0,
+      expense: Number(counts.expense) || 0,
+      total: Number(counts.total) || (Number(counts.income) || 0) + (Number(counts.expense) || 0),
+    },
+  };
+};
+
+const normalizeAggregateByProject = (aggregate) => {
+  if (!aggregate || typeof aggregate !== "object") {
+    return null;
+  }
+
+  return {
+    projectId: aggregate.projectId ?? "",
+    projectName: aggregate.projectName ?? null,
+    income: Number(aggregate.income) || 0,
+    expense: Number(aggregate.expense) || 0,
+    balance: Number(aggregate.balance) || 0,
+    transactionCount: Number(aggregate.transactionCount) || 0,
+  };
+};
+
+const normalizeProjects = (projects) => {
+  if (!Array.isArray(projects)) {
+    return [];
+  }
+
+  return projects
+    .map((project) => {
+      if (!project || typeof project !== "object") {
+        return null;
+      }
+      const value = project.value ?? project.id ?? "";
+      if (!value) {
+        return null;
+      }
+      return {
+        id: project.id ?? value,
+        name: project.name ?? project.label ?? "",
+        label: project.label ?? project.name ?? "",
+        value,
+      };
+    })
+    .filter(Boolean);
+};
+
+const normalizeTransactionTypes = (types) => {
+  if (!Array.isArray(types)) {
+    return [];
+  }
+
+  return types
+    .map((item) => {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+      const value = item.value ?? "";
+      if (!value) {
+        return null;
+      }
+      return {
+        label: item.label ?? value,
+        value,
+      };
+    })
+    .filter(Boolean);
+};
+
+export async function fetchSummaryFilters({ signal } = {}) {
+  const response = await apiJSON(SUMMARY_FILTERS_ENDPOINT, { method: "GET", signal });
+
+  return {
+    projects: normalizeProjects(response?.projects),
+    transactionTypes: normalizeTransactionTypes(response?.transactionTypes),
+  };
+}
+
+export async function fetchSummaryReport({
+  projectId,
+  type,
+  startDate,
+  endDate,
+  limit,
+  cursor,
+  sort,
+  signal,
+} = {}) {
+  const queryString = buildQueryString({ projectId, type, startDate, endDate, limit, cursor, sort });
+  const response = await apiJSON(`${SUMMARY_ENDPOINT}${queryString}`, { method: "GET", signal });
+
+  const transactions = Array.isArray(response?.transactions)
+    ? response.transactions.map(normalizeTransaction).filter(Boolean)
+    : [];
+
+  const summary = normalizeSummary(response?.summary);
+
+  const pageInfo = {
+    hasNextPage: Boolean(response?.pageInfo?.hasNextPage),
+    nextCursor: response?.pageInfo?.nextCursor ?? null,
+    limit: response?.pageInfo?.limit ?? limit ?? 20,
+  };
+
+  const totalCount = typeof response?.totalCount === "number" ? response.totalCount : transactions.length;
+
+  const aggregates = {
+    byProject: Array.isArray(response?.aggregates?.byProject)
+      ? response.aggregates.byProject.map(normalizeAggregateByProject).filter(Boolean)
+      : [],
+  };
+
+  return { transactions, summary, pageInfo, totalCount, aggregates };
+}

--- a/client/src/lib/query-keys.js
+++ b/client/src/lib/query-keys.js
@@ -33,7 +33,7 @@ export const qk = {
   reports: {
     filters: () => ["reports", "filters"],
     charts: () => ["reports", "charts"],
-    summaryTable: () => ["reports", "summary-table"],
+    summaryTable: (params) => ["reports", "summary-table", normalizeParams(params)],
   },
   plans: {
     all: () => ["plans", "all"],


### PR DESCRIPTION
## Summary
- replace the summary page's mock data with TanStack Query calls to the `/api/reports/summary` endpoint, supporting pagination and live updates
- load available filter options and totals from the backend and surface the returned summary metrics in the UI
- add report query utilities and enhance the summary query key to include filter parameters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e23d21cc34832e9384f7609ee78adc