### PR TITLE
Add reporting filters and chart APIs

### DIFF
--- a/server/controllers/reportController.js
+++ b/server/controllers/reportController.js
@@ -9,7 +9,286 @@ const {
     buildTransactionCursorFilter,
     toStorageType,
     parseTransactionDate,
+    toResponseDate,
 } = require('../utils/transactionQueryHelpers');
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    year: 'numeric',
+});
+
+const formatMonthLabel = (year, month) => {
+    if (!Number.isFinite(year) || !Number.isFinite(month)) {
+        return '';
+    }
+
+    const date = new Date(Date.UTC(year, month - 1, 1));
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+
+    return monthFormatter.format(date);
+};
+
+const toSafeNumber = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+};
+
+const getReportFilters = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const userIdentifier = toObjectIdOrNull(userId) ?? userId;
+
+        const [projects, rangeAggregation] = await Promise.all([
+            Project.find({ user_id: userIdentifier })
+                .select({ name: 1 })
+                .sort({ name: 1 })
+                .lean(),
+            Transaction.aggregate([
+                { $match: { user_id: userIdentifier } },
+                {
+                    $group: {
+                        _id: null,
+                        earliest: { $min: '$transaction_date' },
+                        latest: { $max: '$transaction_date' },
+                    },
+                },
+            ]),
+        ]);
+
+        const rangeResult = rangeAggregation[0] || {};
+        const earliest = rangeResult.earliest ? toResponseDate(rangeResult.earliest) : null;
+        const latest = rangeResult.latest ? toResponseDate(rangeResult.latest) : null;
+
+        res.status(200).json({
+            projects: projects.map((project) => ({
+                id: project._id.toString(),
+                name: project.name,
+                label: project.name,
+                value: project._id.toString(),
+            })),
+            transactionTypes: [
+                { label: 'Income', value: 'income' },
+                { label: 'Expense', value: 'expense' },
+            ],
+            dateRange: {
+                earliest,
+                latest,
+            },
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+const getCharts = async (req, res, next) => {
+    try {
+        const userId = req.user?._id;
+        const { projectId, type, startDate, endDate } = req.query;
+
+        const userIdentifier = toObjectIdOrNull(userId) ?? userId;
+        const filters = [{ user_id: userIdentifier }];
+
+        if (projectId) {
+            const projectFilter = toObjectIdOrNull(projectId);
+            if (!projectFilter) {
+                return res.status(400).json({ message: 'Invalid project identifier provided.' });
+            }
+            filters.push({ project_id: projectFilter });
+        }
+
+        let storageType = null;
+        if (type) {
+            storageType = toStorageType(type);
+            if (!storageType) {
+                return res.status(400).json({ message: 'Invalid transaction type filter provided.' });
+            }
+            filters.push({ type: storageType });
+        }
+
+        let parsedStartDate = null;
+        let parsedEndDate = null;
+        if (startDate || endDate) {
+            const dateFilter = {};
+            if (startDate) {
+                parsedStartDate = parseTransactionDate(startDate);
+                if (!parsedStartDate) {
+                    return res.status(400).json({ message: 'Invalid startDate provided.' });
+                }
+                dateFilter.$gte = parsedStartDate;
+            }
+            if (endDate) {
+                parsedEndDate = parseTransactionDate(endDate);
+                if (!parsedEndDate) {
+                    return res.status(400).json({ message: 'Invalid endDate provided.' });
+                }
+                dateFilter.$lte = parsedEndDate;
+            }
+
+            if (dateFilter.$gte && dateFilter.$lte && dateFilter.$gte > dateFilter.$lte) {
+                return res.status(400).json({ message: 'startDate cannot be later than endDate.' });
+            }
+
+            filters.push({ transaction_date: dateFilter });
+        }
+
+        const matchStage = filters.length > 1 ? { $and: filters } : filters[0];
+
+        const [monthlyAggregation, categoryAggregation, statsAggregation] = await Promise.all([
+            Transaction.aggregate([
+                { $match: matchStage },
+                {
+                    $group: {
+                        _id: {
+                            year: { $year: '$transaction_date' },
+                            month: { $month: '$transaction_date' },
+                        },
+                        income: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_in'] }, '$amount', 0],
+                            },
+                        },
+                        expense: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_out'] }, '$amount', 0],
+                            },
+                        },
+                    },
+                },
+                { $sort: { '_id.year': 1, '_id.month': 1 } },
+            ]),
+            Transaction.aggregate([
+                { $match: matchStage },
+                {
+                    $group: {
+                        _id: '$subcategory',
+                        expense: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_out'] }, '$amount', 0],
+                            },
+                        },
+                    },
+                },
+            ]),
+            Transaction.aggregate([
+                { $match: matchStage },
+                {
+                    $group: {
+                        _id: null,
+                        income: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_in'] }, '$amount', 0],
+                            },
+                        },
+                        expense: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_out'] }, '$amount', 0],
+                            },
+                        },
+                        incomeCount: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_in'] }, 1, 0],
+                            },
+                        },
+                        expenseCount: {
+                            $sum: {
+                                $cond: [{ $eq: ['$type', 'cash_out'] }, 1, 0],
+                            },
+                        },
+                        totalCount: { $sum: 1 },
+                        earliest: { $min: '$transaction_date' },
+                        latest: { $max: '$transaction_date' },
+                    },
+                },
+            ]),
+        ]);
+
+        const incomeVsExpense = monthlyAggregation
+            .map((item) => {
+                const year = item._id?.year;
+                const month = item._id?.month;
+                const label = formatMonthLabel(year, month);
+
+                if (!label) {
+                    return null;
+                }
+
+                return {
+                    month: label,
+                    income: toSafeNumber(item.income),
+                    expense: toSafeNumber(item.expense),
+                };
+            })
+            .filter(Boolean);
+
+        const cashFlow = incomeVsExpense.map((item) => ({
+            month: item.month,
+            cashIn: item.income,
+            cashOut: item.expense,
+        }));
+
+        const expenseByCategory = categoryAggregation
+            .map((item) => {
+                const name = typeof item._id === 'string' ? item._id.trim() : '';
+                const value = toSafeNumber(item.expense);
+
+                if (!name || value <= 0) {
+                    return null;
+                }
+
+                return { name, value };
+            })
+            .filter(Boolean)
+            .sort((a, b) => {
+                if (b.value === a.value) {
+                    return a.name.localeCompare(b.name);
+                }
+                return b.value - a.value;
+            });
+
+        const stats = statsAggregation[0] || {};
+        const totalIncome = toSafeNumber(stats.income);
+        const totalExpense = toSafeNumber(stats.expense);
+        const incomeCount = toSafeNumber(stats.incomeCount);
+        const expenseCount = toSafeNumber(stats.expenseCount);
+        const totalCount = toSafeNumber(stats.totalCount);
+
+        const appliedStart = parsedStartDate || stats.earliest || null;
+        const appliedEnd = parsedEndDate || stats.latest || null;
+
+        res.status(200).json({
+            incomeVsExpense,
+            expenseByCategory,
+            cashFlow,
+            summary: {
+                income: totalIncome,
+                expense: totalExpense,
+                balance: totalIncome - totalExpense,
+                counts: {
+                    income: toSafeNumber(incomeCount),
+                    expense: toSafeNumber(expenseCount),
+                    total: toSafeNumber(totalCount),
+                },
+            },
+            dateRange: {
+                start: appliedStart ? toResponseDate(appliedStart) : null,
+                end: appliedEnd ? toResponseDate(appliedEnd) : null,
+            },
+            filters: {
+                projectId: projectId ?? null,
+                type: type ?? null,
+                storageType,
+            },
+        });
+    } catch (error) {
+        next(error);
+    }
+};
 
 const getSummary = async (req, res, next) => {
     try {
@@ -304,6 +583,8 @@ const getSummaryFilters = async (req, res, next) => {
 };
 
 module.exports = {
+    getReportFilters,
+    getCharts,
     getSummary,
     getSummaryFilters,
 };

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -5,10 +5,20 @@ const reportController = require('../controllers/reportController');
 const { authenticate } = require('../middleware/authMiddleware');
 const {
     summaryListValidationRules,
+    reportChartsValidationRules,
     handleValidationErrors,
 } = require('../validators/validatorsIndex');
 
 router.use(authenticate);
+
+router.get('/filters', reportController.getReportFilters);
+
+router.get(
+    '/charts',
+    reportChartsValidationRules(),
+    handleValidationErrors,
+    reportController.getCharts,
+);
 
 router.get(
     '/summary',

--- a/server/validators/reportValidators.js
+++ b/server/validators/reportValidators.js
@@ -38,6 +38,25 @@ const summaryListValidationRules = () => [
         .isLength({ max: 200 }).withMessage('Subcategory must be 200 characters or fewer.'),
 ];
 
+const reportChartsValidationRules = () => [
+    query('projectId')
+        .optional()
+        .isMongoId().withMessage('projectId must be a valid identifier when provided.'),
+    query('type')
+        .optional()
+        .isIn(['income', 'expense']).withMessage('Type filter must be either "income" or "expense".')
+        .toLowerCase(),
+    query('startDate')
+        .optional()
+        .isISO8601().withMessage('startDate must be a valid ISO 8601 date.')
+        .trim(),
+    query('endDate')
+        .optional()
+        .isISO8601().withMessage('endDate must be a valid ISO 8601 date.')
+        .trim(),
+];
+
 module.exports = {
     summaryListValidationRules,
+    reportChartsValidationRules,
 };

--- a/server/validators/validatorsIndex.js
+++ b/server/validators/validatorsIndex.js
@@ -62,5 +62,6 @@ module.exports = {
     transactionIdParamValidationRules: projectValidators.transactionIdParamValidationRules,
     transactionListValidationRules: projectValidators.transactionListValidationRules,
     summaryListValidationRules: reportValidators.summaryListValidationRules,
+    reportChartsValidationRules: reportValidators.reportChartsValidationRules,
     handleValidationErrors,
 };


### PR DESCRIPTION
## Summary
- add an authenticated `/api/reports/filters` endpoint that exposes project options, transaction types, and transaction date bounds
- implement `/api/reports/charts` with aggregated income/expense timelines, cash flow series, category totals, and summary metadata driven by query filters
- register validation middleware and routing for the new reporting endpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2b0c70ef4832e8cf8e0ca6910e8ac